### PR TITLE
handle parent correctly in doc and collection

### DIFF
--- a/packages/firestore/lib/modular/index.js
+++ b/packages/firestore/lib/modular/index.js
@@ -35,6 +35,11 @@ export function doc(parent, path, ...pathSegments) {
   if (pathSegments && pathSegments.length) {
     path = path + '/' + pathSegments.map(e => e.replace(/^\/|\/$/g, '')).join('/');
   }
+  
+  if ('collection' in parent) {
+    const [firstSegment, ...restSegments] = path.split('/');
+    return parent.collection(firstSegment).doc(restSegments.join('/'));
+  }
 
   return parent.doc(path);
 }
@@ -48,6 +53,11 @@ export function doc(parent, path, ...pathSegments) {
 export function collection(parent, path, ...pathSegments) {
   if (pathSegments && pathSegments.length) {
     path = path + '/' + pathSegments.map(e => e.replace(/^\/|\/$/g, '')).join('/');
+  }
+
+  if ('doc' in parent) {
+    const [firstSegment, ...restSegments] = path.split('/');
+    return parent.doc(firstSegment).collection(restSegments.join('/'));
   }
 
   return parent.collection(path);


### PR DESCRIPTION
### Description

Previously, `doc()` and `collection()` assumed `parent` to be a Collection and Document respectively.

But I belive this is not the indended behaviour as we provided the overload for them to take in `Collection | Document`. See [here](https://github.com/invertase/react-native-firebase/blob/ad40ea2eb828a59451a619059bb4bef96277e23f/packages/firestore/lib/modular/index.d.ts#L213-L217).

This commit adds support to this.

### Related issues

N/A

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
